### PR TITLE
Code cleanups

### DIFF
--- a/include/sliding_window/search/query_result.hpp
+++ b/include/sliding_window/search/query_result.hpp
@@ -21,11 +21,9 @@ public:
     query_result & operator=(query_result &&) = default;
     ~query_result() = default;
 
-    query_result(std::string const query_id, std::set<size_t> const & query_hits)
-    {
-        id = query_id;
-        bin_hits = query_hits; 
-    }
+    query_result(std::string query_id, std::set<size_t> query_hits)
+        : id{std::move(query_id)}, bin_hits{std::move(query_hits)}
+    {}
 
     const std::set<size_t>& get_hits() const
     {
@@ -36,7 +34,6 @@ public:
     {
         return id;
     }
-    
 };
 
 } // namespace sliding_window

--- a/include/sliding_window/search/query_result.hpp
+++ b/include/sliding_window/search/query_result.hpp
@@ -32,7 +32,7 @@ public:
         return bin_hits;
     }
 
-    std::string get_id()
+    const std::string & get_id() const
     {
         return id;
     }

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -148,7 +148,6 @@ std::vector<query_result> worker(size_t const start,
     size_t const bin_count = ibf.bin_count();
 
     std::vector<query_result> thread_result{}; // set of query results processed by one thread
-    std::set<size_t> sequence_hits{};          // bin hits for one sequence
 
     // vector holding all the minimisers and their starting position for the read
     using minimiser_vec_t = std::vector<std::tuple<uint64_t, size_t>>;
@@ -160,8 +159,6 @@ std::vector<query_result> worker(size_t const start,
 
     for (auto &&[id, seq] : records | seqan3::views::slice(start, end))
     {
-        sequence_hits.clear();
-
         minimiser = seq | hash_tuple_view | seqan3::views::to<minimiser_vec_t>;
 
         //-----------------------------
@@ -222,6 +219,7 @@ std::vector<query_result> worker(size_t const start,
         // AACG		AACGCGGC
         //
         //-----------------------------
+        std::set<size_t> sequence_hits{};
         for (size_t const begin : begin_vector)
         {
             pattern_bounds const pattern = make_pattern_bounds(begin, arguments, window_span_begin, window_span_end, threshold_data);
@@ -229,7 +227,7 @@ std::vector<query_result> worker(size_t const start,
             sequence_hits.insert(pattern_hits.begin(), pattern_hits.end());
         }
 
-        thread_result.emplace_back(id, sequence_hits);
+        thread_result.emplace_back(id, std::move(sequence_hits));
     }
 
     return thread_result;

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -144,8 +144,8 @@ std::vector<query_result> worker(size_t const start,
 {
     // concurrent invocations of the membership agent are not thread safe
     // agent has to be created for each thread
-    auto &&agent = ibf.membership_agent();
-    size_t bin_count = ibf.bin_count();
+    auto agent = ibf.membership_agent();
+    size_t const bin_count = ibf.bin_count();
 
     std::vector<query_result> thread_result{}; // set of query results processed by one thread
     std::set<size_t> sequence_hits{};          // bin hits for one sequence
@@ -197,7 +197,7 @@ std::vector<query_result> worker(size_t const start,
         {
             const auto &[min, start_pos] = minimiser[i];
             window_span_begin[i] = start_pos;
-            size_t end_pos = start_pos + arguments.window_size - 2;
+            size_t const end_pos = start_pos + arguments.window_size - 2;
             window_span_end[i - 1] = end_pos;
             counting_table[i].raw_data() |= agent.bulk_contains(min).raw_data();
         }
@@ -222,15 +222,14 @@ std::vector<query_result> worker(size_t const start,
         // AACG		AACGCGGC
         //
         //-----------------------------
-        for (size_t begin : begin_vector)
+        for (size_t const begin : begin_vector)
         {
             pattern_bounds const pattern = make_pattern_bounds(begin, arguments, window_span_begin, window_span_end, threshold_data);
             std::set<size_t> const pattern_hits = find_pattern_bins(pattern, bin_count, counting_table);
             sequence_hits.insert(pattern_hits.begin(), pattern_hits.end());
         }
 
-        query_result query_result(id, sequence_hits);
-        thread_result.emplace_back(query_result);
+        thread_result.emplace_back(id, sequence_hits);
     }
 
     return thread_result;

--- a/include/sliding_window/search/write_output_file_parallel.hpp
+++ b/include/sliding_window/search/write_output_file_parallel.hpp
@@ -45,13 +45,13 @@ inline void write_output_file_parallel(worker_t && worker,
         // auto result_set = task.get();
         std::string result_string{};
         std::vector<query_result> thread_result = task.get();
-        for (auto query_result : thread_result)
+        for (query_result const & query_result : thread_result)
         {
             result_string.clear();
             result_string += query_result.get_id();
             result_string += '\t';
-                
-            for (auto bin : query_result.get_hits())
+
+            for (size_t const bin : query_result.get_hits())
             {
                 result_string += std::to_string(bin);
                 result_string += ',';

--- a/src/sliding_window_search.cpp
+++ b/src/sliding_window_search.cpp
@@ -8,10 +8,9 @@ namespace sliding_window::app
 // Setup IBF and launch multithreaded search.
 //
 //-----------------------------
-template <bool compressed>
+template <seqan3::data_layout ibf_data_layout>
 void run_program(search_arguments const &arguments, search_time_statistics & time_statistics)
 {
-    constexpr seqan3::data_layout ibf_data_layout = compressed ? seqan3::data_layout::compressed : seqan3::data_layout::uncompressed;
     seqan3::interleaved_bloom_filter<ibf_data_layout> ibf{};
 
     auto cereal_worker = [&]()
@@ -56,9 +55,9 @@ void sliding_window_search(search_arguments const & arguments)
     search_time_statistics time_statistics{};
 
     if (arguments.compressed)
-        run_program<true>(arguments, time_statistics);
+        run_program<seqan3::data_layout::compressed>(arguments, time_statistics);
     else
-        run_program<false>(arguments, time_statistics);
+        run_program<seqan3::data_layout::uncompressed>(arguments, time_statistics);
 
     if (arguments.write_time)
         write_time_statistics(time_statistics, arguments);


### PR DESCRIPTION
Makes more variables `const`, changes the way a `query_result` is constructed by using `std::move` to transfer data ownership and some smaller code "clean-ups".