### PR TITLE
Pull `worker` out

### DIFF
--- a/include/sliding_window/search/local_prefilter.hpp
+++ b/include/sliding_window/search/local_prefilter.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+#include <seqan3/std/span>
+
+#include <seqan3/search/dream_index/interleaved_bloom_filter.hpp>
+
+#include <sliding_window/search/compute_simple_model.hpp> // threshold
+#include <sliding_window/search/query_record.hpp>
+#include <sliding_window/search/query_result.hpp>
+#include <sliding_window/shared.hpp> // search_arguments
+
+namespace sliding_window
+{
+
+struct local_prefilter_fn
+{
+    // NOTE: definition is in include/sliding_window/search/search_setup.hpp
+    // TODO: move definition into this file
+    template <seqan3::data_layout ibf_data_layout>
+    std::vector<query_result>
+    operator()(std::span<query_record const> const & records,
+               seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
+               search_arguments const & arguments,
+               threshold const & threshold_data) const;
+};
+
+static constexpr local_prefilter_fn local_prefilter{};
+
+} // namespace sliding_window

--- a/include/sliding_window/search/query_record.hpp
+++ b/include/sliding_window/search/query_record.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+
+namespace sliding_window
+{
+
+struct query_record
+{
+// workaround for gcc 9.x; for some reasons std::vector<query_record>::emplace_back() can't be used
+// if this constructor is missing
+#if defined(__GNUC__) && __GNUC__ <= 9
+    query_record() = default;
+    query_record(size_t record_id, std::string sequence_id, std::vector<seqan3::dna4> sequence)
+        : record_id{record_id}, sequence_id{std::move(sequence_id)}, sequence{std::move(sequence)}
+    {}
+#endif // defined(__GNUC__) && __GNUC__ <= 9
+
+    size_t record_id;
+    std::string sequence_id;
+    std::vector<seqan3::dna4> sequence;
+};
+
+} // namespace sliding_window

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <seqan3/std/span>
+
 #include <seqan3/core/debug_stream.hpp>
-#include <seqan3/utility/views/slice.hpp> // provides views::slice
 
 #include <sliding_window/search/compute_simple_model.hpp>
 #include <sliding_window/search/write_output_file_parallel.hpp>
@@ -158,7 +159,8 @@ std::vector<query_result> worker(size_t const start,
                                                     window_size{arguments.window_size},
                                                     seed{adjust_seed(arguments.kmer_size)});
 
-    for (query_record const & record : records | seqan3::views::slice(start, end))
+    std::span<query_record const> record_slice{&records[start], &records[end]};
+    for (query_record const & record : record_slice)
     {
         std::string const & id = record.sequence_id;
         std::vector<seqan3::dna4> const & seq = record.sequence;

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -6,6 +6,7 @@
 #include <sliding_window/search/compute_simple_model.hpp>
 #include <sliding_window/search/write_output_file_parallel.hpp>
 #include <sliding_window/search/load_ibf.hpp>
+#include <sliding_window/search/query_record.hpp>
 #include <sliding_window/search/query_result.hpp>
 #include <sliding_window/search/sync_out.hpp>
 
@@ -72,10 +73,10 @@ struct pattern_bounds
 };
 
 template <typename span_vec_t>
-pattern_bounds make_pattern_bounds(size_t const & begin, 
-                                   search_arguments const & arguments, 
-                                   span_vec_t const & window_span_begin, 
-                                   span_vec_t const & window_span_end, 
+pattern_bounds make_pattern_bounds(size_t const & begin,
+                                   search_arguments const & arguments,
+                                   span_vec_t const & window_span_begin,
+                                   span_vec_t const & window_span_end,
                                    threshold const & threshold_data)
 {
     auto pattern = pattern_bounds{};
@@ -91,10 +92,10 @@ pattern_bounds make_pattern_bounds(size_t const & begin,
 
     size_t const minimiser_count = pattern.last_index - pattern.first_index + 1;
 
-    pattern.threshold = arguments.treshold_was_set ? 
-                            static_cast<size_t>(minimiser_count * arguments.threshold) : threshold_data.kmers_per_window == 1 ? 
-                            threshold_data.kmer_lemma : threshold_data.precomp_thresholds[std::min(minimiser_count < threshold_data.min_number_of_minimisers ? 
-                            0 : minimiser_count - threshold_data.min_number_of_minimisers,  
+    pattern.threshold = arguments.treshold_was_set ?
+                            static_cast<size_t>(minimiser_count * arguments.threshold) : threshold_data.kmers_per_window == 1 ?
+                            threshold_data.kmer_lemma : threshold_data.precomp_thresholds[std::min(minimiser_count < threshold_data.min_number_of_minimisers ?
+                            0 : minimiser_count - threshold_data.min_number_of_minimisers,
                             threshold_data.max_number_of_minimisers - threshold_data.min_number_of_minimisers)] + 2; // enrico recommended decreasing this value
 
     return pattern;
@@ -134,10 +135,10 @@ std::set<size_t> find_pattern_bins(pattern_bounds const & pattern, size_t const 
 //
 // TODO: pass slice of records directly instead of start, end and records
 //-----------------------------
-template <seqan3::data_layout ibf_data_layout, typename rec_vec_t>
+template <seqan3::data_layout ibf_data_layout>
 std::vector<query_result> worker(size_t const start,
                                  size_t const end,
-                                 rec_vec_t const & records,
+                                 std::vector<query_record> const & records,
                                  seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
                                  search_arguments const & arguments,
                                  threshold const & threshold_data)
@@ -157,8 +158,11 @@ std::vector<query_result> worker(size_t const start,
                                                     window_size{arguments.window_size},
                                                     seed{adjust_seed(arguments.kmer_size)});
 
-    for (auto &&[id, seq] : records | seqan3::views::slice(start, end))
+    for (query_record const & record : records | seqan3::views::slice(start, end))
     {
+        std::string const & id = record.sequence_id;
+        std::vector<seqan3::dna4> const & seq = record.sequence;
+
         minimiser = seq | hash_tuple_view | seqan3::views::to<minimiser_vec_t>;
 
         //-----------------------------

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -7,6 +7,7 @@
 #include <sliding_window/search/compute_simple_model.hpp>
 #include <sliding_window/search/write_output_file_parallel.hpp>
 #include <sliding_window/search/load_ibf.hpp>
+#include <sliding_window/search/local_prefilter.hpp>
 #include <sliding_window/search/query_record.hpp>
 #include <sliding_window/search/query_result.hpp>
 #include <sliding_window/search/sync_out.hpp>
@@ -136,10 +137,12 @@ std::set<size_t> find_pattern_bins(pattern_bounds const & pattern, size_t const 
 //
 //-----------------------------
 template <seqan3::data_layout ibf_data_layout>
-std::vector<query_result> worker(std::span<query_record const> const & records,
-                                 seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
-                                 search_arguments const & arguments,
-                                 threshold const & threshold_data)
+std::vector<query_result>
+local_prefilter_fn::operator()(
+    std::span<query_record const> const & records,
+    seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
+    search_arguments const & arguments,
+    threshold const & threshold_data) const
 {
     // concurrent invocations of the membership agent are not thread safe
     // agent has to be created for each thread

--- a/include/sliding_window/search/search_setup.hpp
+++ b/include/sliding_window/search/search_setup.hpp
@@ -132,14 +132,11 @@ std::set<size_t> find_pattern_bins(pattern_bounds const & pattern, size_t const 
 
 //-----------------------------
 //
-// Search a batch of reads (start; end) in the IBF
+// Search a batch of reads in the IBF
 //
-// TODO: pass slice of records directly instead of start, end and records
 //-----------------------------
 template <seqan3::data_layout ibf_data_layout>
-std::vector<query_result> worker(size_t const start,
-                                 size_t const end,
-                                 std::vector<query_record> const & records,
+std::vector<query_result> worker(std::span<query_record const> const & records,
                                  seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
                                  search_arguments const & arguments,
                                  threshold const & threshold_data)
@@ -159,8 +156,7 @@ std::vector<query_result> worker(size_t const start,
                                                     window_size{arguments.window_size},
                                                     seed{adjust_seed(arguments.kmer_size)});
 
-    std::span<query_record const> record_slice{&records[start], &records[end]};
-    for (query_record const & record : record_slice)
+    for (query_record const & record : records)
     {
         std::string const & id = record.sequence_id;
         std::vector<seqan3::dna4> const & seq = record.sequence;

--- a/include/sliding_window/search/write_output_file_parallel.hpp
+++ b/include/sliding_window/search/write_output_file_parallel.hpp
@@ -8,6 +8,7 @@
 
 #include <sliding_window/shared.hpp>
 #include <sliding_window/search/compute_simple_model.hpp>
+#include <sliding_window/search/query_record.hpp>
 #include <sliding_window/search/query_result.hpp>
 #include <sliding_window/search/sync_out.hpp>
 
@@ -17,11 +18,11 @@ namespace sliding_window::app
 
 // && worker means only r-value references (temporary objects) can be passed
 // which means the memory can be reallocated after the function exits
-template <typename worker_t, seqan3::data_layout ibf_data_layout, typename rec_vec_t>
+template <typename worker_t, seqan3::data_layout ibf_data_layout>
 inline void write_output_file_parallel(worker_t && worker,
                                        seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
                                        search_arguments const & arguments,
-                                       rec_vec_t const & records,
+                                       std::vector<query_record> const & records,
                                        threshold const & threshold_data,
                                        sync_out & synced_out)
 {

--- a/include/sliding_window/search/write_output_file_parallel.hpp
+++ b/include/sliding_window/search/write_output_file_parallel.hpp
@@ -18,8 +18,7 @@ namespace sliding_window::app
 {
 
 template <seqan3::data_layout ibf_data_layout>
-inline void write_output_file_parallel(local_prefilter_fn const local_prefilter,
-                                       seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
+inline void write_output_file_parallel(seqan3::interleaved_bloom_filter<ibf_data_layout> const & ibf,
                                        search_arguments const & arguments,
                                        std::vector<query_record> const & records,
                                        threshold const & threshold_data,

--- a/src/sliding_window_search.cpp
+++ b/src/sliding_window_search.cpp
@@ -46,10 +46,8 @@ void run_program(search_arguments const &arguments, search_time_statistics & tim
 
         cereal_handle.wait();
 
-        // not allowed to pass template functions to other functions, 
-        // BUT allowed to pass specific instances of template functions to other functions
         start = std::chrono::high_resolution_clock::now();
-        write_output_file_parallel(local_prefilter, ibf, arguments, query_records, threshold_data, synced_out);
+        write_output_file_parallel(ibf, arguments, query_records, threshold_data, synced_out);
         end = std::chrono::high_resolution_clock::now();
         time_statistics.compute_time += std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
     }

--- a/src/sliding_window_search.cpp
+++ b/src/sliding_window_search.cpp
@@ -1,3 +1,4 @@
+#include <sliding_window/search/query_record.hpp>
 #include <sliding_window/search/search_setup.hpp>
 
 namespace sliding_window::app
@@ -24,18 +25,22 @@ void run_program(search_arguments const &arguments, search_time_statistics & tim
     auto cereal_handle = std::async(std::launch::async, cereal_worker);
 
     seqan3::sequence_file_input<dna4_traits, seqan3::fields<seqan3::field::id, seqan3::field::seq>> fin{arguments.query_file};
-    using record_type = typename decltype(fin)::record_type;
-    std::vector<record_type> records{};
+    std::vector<query_record> query_records{};
 
     threshold const threshold_data = make_threshold_data(arguments);
 
     sync_out synced_out{arguments.out_file};
 
+    size_t record_id = 0u;
     for (auto &&chunked_records : fin | seqan3::views::chunk((1ULL << 20) * 10))
     {
-        records.clear();
+        query_records.clear();
         auto start = std::chrono::high_resolution_clock::now();
-        std::ranges::move(chunked_records, std::cpp20::back_inserter(records));
+        for (auto && query_record: chunked_records)
+        {
+            query_records.emplace_back(record_id, std::move(query_record.id()), std::move(query_record.sequence()));
+            ++record_id;
+        }
         auto end = std::chrono::high_resolution_clock::now();
         time_statistics.reads_io_time += std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
 
@@ -44,7 +49,7 @@ void run_program(search_arguments const &arguments, search_time_statistics & tim
         // not allowed to pass template functions to other functions, 
         // BUT allowed to pass specific instances of template functions to other functions
         start = std::chrono::high_resolution_clock::now();
-        write_output_file_parallel(worker<ibf_data_layout, std::vector<record_type>>, ibf, arguments, records, threshold_data, synced_out);
+        write_output_file_parallel(worker<ibf_data_layout>, ibf, arguments, query_records, threshold_data, synced_out);
         end = std::chrono::high_resolution_clock::now();
         time_statistics.compute_time += std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
     }

--- a/src/sliding_window_search.cpp
+++ b/src/sliding_window_search.cpp
@@ -49,7 +49,7 @@ void run_program(search_arguments const &arguments, search_time_statistics & tim
         // not allowed to pass template functions to other functions, 
         // BUT allowed to pass specific instances of template functions to other functions
         start = std::chrono::high_resolution_clock::now();
-        write_output_file_parallel(worker<ibf_data_layout>, ibf, arguments, query_records, threshold_data, synced_out);
+        write_output_file_parallel(local_prefilter, ibf, arguments, query_records, threshold_data, synced_out);
         end = std::chrono::high_resolution_clock::now();
         time_statistics.compute_time += std::chrono::duration_cast<std::chrono::duration<double>>(end - start).count();
     }


### PR DESCRIPTION
This PR does:

* making `worker` a functor.
* renaming `worker` to a more meaningful name `local_prefilter`
* passes the `records` via a `std::span` instead of locally applying the `slice` view.
* introduces a new `query_record` which is an app defined record to make it more predictable what the "input" is.

Some future considerations: It seems that `include/sliding_window/search/search_setup.hpp` is everything needed to do the `local_prefilter`. We might want to make all these helper functions part of the functor to show "what is important and unimportant to make everything work."